### PR TITLE
Here's a fix for teavms resize issue and a couple improvements

### DIFF
--- a/core/src/main/kotlin/io/github/thanosfisherman/gasket/Circle.kt
+++ b/core/src/main/kotlin/io/github/thanosfisherman/gasket/Circle.kt
@@ -4,11 +4,9 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer
 import com.badlogic.gdx.math.Vector2
-import com.badlogic.gdx.utils.viewport.Viewport
 import ktx.graphics.center
 
 data class Circle(
-    private val viewport: Viewport,
     var x: Float = 0f,
     var y: Float = 0f,
     var bend: Float = 0f,
@@ -19,15 +17,6 @@ data class Circle(
 
     var center = Complex(x, y)
     var radius = kotlin.math.abs(1 / bend)
-
-    private val width = Gdx.graphics.width.toFloat()
-    private val height = Gdx.graphics.height.toFloat()
-
-    init {
-        viewport.camera.center(width, height)
-        shape.projectionMatrix = viewport.camera.combined
-        Gdx.gl.glLineWidth(1.64f)
-    }
 
     fun init(
         x: Float = 0f,
@@ -53,27 +42,15 @@ data class Circle(
         this.isCone = isCone
     }
 
-    companion object {
-        private val shape = ShapeRenderer()
 
-        fun dispose() {
-            shape.dispose()
-        }
-    }
+    fun draw(shape: ShapeRenderer, x: Float = this.center.real, y: Float = this.center.img, color: Color = this.color) {
 
-
-    fun draw(x: Float = this.center.real, y: Float = this.center.img, color: Color = this.color) {
-
-        viewport.apply(true)
-        shape.begin(ShapeRenderer.ShapeType.Line)
         shape.color = color
 
         if (isCone)
             shape.cone(x, y, 0f, radius, 0f, segments)
         else
             shape.circle(x, y, radius, 200)
-
-        shape.end()
     }
 
     fun distance(other: Circle): Float {

--- a/core/src/main/kotlin/io/github/thanosfisherman/gasket/FirstScreen.kt
+++ b/core/src/main/kotlin/io/github/thanosfisherman/gasket/FirstScreen.kt
@@ -28,7 +28,7 @@ class FirstScreen(private val game: Game) : KtxScreen {
     private val shape = ShapeRenderer()
 
     private val fps = FrameRate()
-    private val gasketPool: Pool<Gasket> = pool(30) { Gasket(gameViewport.worldWidth, gameViewport.worldHeight).init() }
+    private val gasketPool: Pool<Gasket> = pool(30) { Gasket(gameViewport.worldWidth, gameViewport.worldHeight) }
     lateinit var gasket: Gasket
 
     override fun show() {
@@ -42,7 +42,6 @@ class FirstScreen(private val game: Game) : KtxScreen {
                 if (keycode == Keys.SPACE) {
                     gasketPool.free(gasket)
                     gasket = gasketPool.obtain()
-                    gasket.init()
                 }
                 if (keycode == Keys.F2) {
                     fps.isRendered = !fps.isRendered
@@ -53,7 +52,6 @@ class FirstScreen(private val game: Game) : KtxScreen {
             override fun touchUp(screenX: Int, screenY: Int, pointer: Int, button: Int): Boolean {
                 gasketPool.free(gasket)
                 gasket = gasketPool.obtain()
-                gasket.init()
                 return true
             }
         }

--- a/core/src/main/kotlin/io/github/thanosfisherman/gasket/FirstScreen.kt
+++ b/core/src/main/kotlin/io/github/thanosfisherman/gasket/FirstScreen.kt
@@ -60,7 +60,9 @@ class FirstScreen(private val game: Game) : KtxScreen {
     override fun render(delta: Float) {
         clearScreen(red = 0f, green = 0f, blue = 0f)
 
-        fps.update()
+        gasket.update(delta)
+        fps.update(delta)
+
 //        vector.set(Gdx.input.x.toFloat(), Gdx.input.y.toFloat(), 0f)
 //        camera.unproject(vector)
 //        Gdx.graphics.setTitle("DEBUG - X: ${vector.x} Y: ${vector.y}")

--- a/core/src/main/kotlin/io/github/thanosfisherman/gasket/FirstScreen.kt
+++ b/core/src/main/kotlin/io/github/thanosfisherman/gasket/FirstScreen.kt
@@ -28,7 +28,7 @@ class FirstScreen(private val game: Game) : KtxScreen {
     private val shape = ShapeRenderer()
 
     private val fps = FrameRate()
-    private val gasketPool: Pool<Gasket> = pool(30) { Gasket(gameViewport.worldWidth, gameViewport.worldHeight) }
+    private val gasketPool: Pool<Gasket> = pool(30) { Gasket(gameViewport.worldWidth, gameViewport.worldHeight).init() }
     lateinit var gasket: Gasket
 
     override fun show() {

--- a/core/src/main/kotlin/io/github/thanosfisherman/gasket/Framerate.kt
+++ b/core/src/main/kotlin/io/github/thanosfisherman/gasket/Framerate.kt
@@ -6,8 +6,6 @@ import com.badlogic.gdx.graphics.g2d.BitmapFont
 import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.badlogic.gdx.utils.Disposable
 import com.badlogic.gdx.utils.TimeUtils
-import com.badlogic.gdx.utils.viewport.ScreenViewport
-import com.badlogic.gdx.utils.viewport.Viewport
 import ktx.assets.disposeSafely
 
 
@@ -17,8 +15,6 @@ class FrameRate : Disposable {
     private var sinceChange = 0f
     private var frameRate: Float
     private val font: BitmapFont
-    private val batch: SpriteBatch
-    private val viewport: Viewport = ScreenViewport()
 
 
     init {
@@ -26,12 +22,6 @@ class FrameRate : Disposable {
         frameRate = Gdx.graphics.framesPerSecond.toFloat()
         font = BitmapFont()
         font.region.texture.setFilter(Texture.TextureFilter.Nearest, Texture.TextureFilter.Nearest)
-        batch = SpriteBatch()
-    }
-
-    fun resize(screenWidth: Int, screenHeight: Int) {
-        viewport.update(screenWidth, screenHeight, true)
-        batch.projectionMatrix = viewport.camera.combined
     }
 
     fun update() {
@@ -47,17 +37,13 @@ class FrameRate : Disposable {
         }
     }
 
-    fun render() {
+    fun render(batch: SpriteBatch) {
         if (!isRendered) return
 
-        viewport.apply(true)
-        batch.begin()
-        font.draw(batch, frameRate.toInt().toString() + " fps", 4f, viewport.worldHeight - 4f)
-        batch.end()
+        font.draw(batch, frameRate.toInt().toString() + " fps", 0f, 16f)
     }
 
     override fun dispose() {
         font.disposeSafely()
-        batch.disposeSafely()
     }
 }

--- a/core/src/main/kotlin/io/github/thanosfisherman/gasket/Framerate.kt
+++ b/core/src/main/kotlin/io/github/thanosfisherman/gasket/Framerate.kt
@@ -24,14 +24,11 @@ class FrameRate : Disposable {
         font.region.texture.setFilter(Texture.TextureFilter.Nearest, Texture.TextureFilter.Nearest)
     }
 
-    fun update() {
+    fun update(delta: Float) {
         if (!isRendered) return
 
-        val delta: Long = TimeUtils.timeSinceMillis(lastTimeCounted)
-        lastTimeCounted = TimeUtils.millis()
-
-        sinceChange += delta.toFloat()
-        if (sinceChange >= 1000) {
+        sinceChange += delta
+        if (sinceChange >= 1f) {
             sinceChange = 0f
             frameRate = Gdx.graphics.framesPerSecond.toFloat()
         }

--- a/core/src/main/kotlin/io/github/thanosfisherman/gasket/Game.kt
+++ b/core/src/main/kotlin/io/github/thanosfisherman/gasket/Game.kt
@@ -2,7 +2,12 @@ package io.github.thanosfisherman.gasket
 
 import com.badlogic.gdx.Application
 import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.graphics.g2d.SpriteBatch
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer
+import com.badlogic.gdx.utils.ScreenUtils
 import com.badlogic.gdx.utils.viewport.FitViewport
+import com.badlogic.gdx.utils.viewport.ScreenViewport
 import com.badlogic.gdx.utils.viewport.Viewport
 import ktx.app.KtxGame
 import ktx.app.KtxScreen
@@ -12,7 +17,6 @@ private val logger = logger<Game>()
 
 class Game : KtxGame<KtxScreen>() {
 
-    val viewport: Viewport = FitViewport(900f, 900f)
 
     override fun create() {
         Gdx.app.logLevel = Application.LOG_DEBUG

--- a/core/src/main/kotlin/io/github/thanosfisherman/gasket/Gasket.kt
+++ b/core/src/main/kotlin/io/github/thanosfisherman/gasket/Gasket.kt
@@ -17,7 +17,7 @@ import kotlin.math.abs
 // Tolerance for calculating tangency and overlap
 private const val epsilon = 1f
 
-class Gasket(private var width: Float, private var height: Float) {
+class Gasket(private var width: Float, private var height: Float) : Pool.Poolable {
     private var coneSegments = intArrayOf(4, 8, 20, 50).random()
     private var isConeShape = RandomXS128().nextInt(3) == 0
     private var colorRandomizer = ColorRandomizer()
@@ -44,7 +44,11 @@ class Gasket(private var width: Float, private var height: Float) {
     // Queue for circles to process for next generation
     private var queue = GdxArray<Triplet>(false, 64)
 
-    fun init(): Gasket {
+    init {
+        reset()
+    }
+
+    override fun reset() {
         coneSegments = intArrayOf(4, 8, 20, 50).random()
         isConeShape = RandomXS128().nextInt(3) == 0
         colorRandomizer = ColorRandomizer()
@@ -111,8 +115,6 @@ class Gasket(private var width: Float, private var height: Float) {
             // Initial triplet for generating next generation of circles
             add(Triplet(c1, c2, c3))
         }
-
-        return this
     }
 
     fun draw(shape: ShapeRenderer) {

--- a/core/src/main/kotlin/io/github/thanosfisherman/gasket/Gasket.kt
+++ b/core/src/main/kotlin/io/github/thanosfisherman/gasket/Gasket.kt
@@ -1,6 +1,7 @@
 package io.github.thanosfisherman.gasket
 
 import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer
 import com.badlogic.gdx.math.MathUtils
 import com.badlogic.gdx.math.MathUtils.PI
 import com.badlogic.gdx.math.RandomXS128
@@ -16,16 +17,13 @@ import kotlin.math.abs
 // Tolerance for calculating tangency and overlap
 private const val epsilon = 1f
 
-class Gasket(viewport: Viewport) {
+class Gasket(private var width: Float, private var height: Float) {
     private var coneSegments = intArrayOf(4, 8, 20, 50).random()
     private var isConeShape = RandomXS128().nextInt(3) == 0
     private var colorRandomizer = ColorRandomizer()
-    private var circlesPool: Pool<Circle> = pool(1200) { Circle(viewport) }
+    private var circlesPool: Pool<Circle> = pool(1200) { Circle() }
     private var lastTimeCounted = TimeUtils.millis()
     private var sinceChange = 0f
-
-    private var width = viewport.worldWidth
-    private var height = viewport.worldHeight
 
     // Initialize first circle centered on canvas
     private var c1 = circlesPool.obtain().also {
@@ -143,7 +141,7 @@ class Gasket(viewport: Viewport) {
         }
     }
 
-    fun draw() {
+    fun draw(shape: ShapeRenderer) {
 
         val delta: Long = TimeUtils.millis() - lastTimeCounted
         lastTimeCounted = TimeUtils.millis()
@@ -154,7 +152,7 @@ class Gasket(viewport: Viewport) {
             nextGeneration()
         }
         for (c in allCircles) {
-            c.draw()
+            c.draw(shape)
         }
     }
 
@@ -188,7 +186,6 @@ class Gasket(viewport: Viewport) {
     fun dispose() {
         circlesPool.clear()
         allCircles.clear()
-        Circle.dispose()
     }
 
     // Determine if two circles are tangent to each other

--- a/core/src/main/kotlin/io/github/thanosfisherman/gasket/Gasket.kt
+++ b/core/src/main/kotlin/io/github/thanosfisherman/gasket/Gasket.kt
@@ -26,53 +26,25 @@ class Gasket(private var width: Float, private var height: Float) {
     private var sinceChange = 0f
 
     // Initialize first circle centered on canvas
-    private var c1 = circlesPool.obtain().also {
-        it.init(
-            width / 2,
-            height / 2,
-            -1 / (width / 2),
-            colorRandomizer.randomColor(),
-            coneSegments,
-            isConeShape
-        )
-    }
+    // Second circle positioned randomly within the first
+    // Third circle also positioned relative to the first
+    private lateinit var c1: Circle; private lateinit var c2: Circle; private lateinit var c3: Circle
 
-    private var r2 = randomFloatRange(100f, c1.radius / 2)
+    private var r2 = 0f; private var r3 = 0f
 
     // Generate a random angle between 0 and 2*PI
-    private var randomAngleRad: Float = randomFloatRange(0f, 2 * PI)
+    private var randomAngleRad: Float = 0f
 
     // Convert the angle to a unit vector
-    private var v = vec2(MathUtils.cos(randomAngleRad), MathUtils.sin(randomAngleRad))
-        .setLength(c1.radius - r2)
-
-    // Second circle positioned randomly within the first
-    private var c2 = circlesPool.obtain().also {
-        it.init(width / 2 + v.x, height / 2 + v.y, 1 / r2, colorRandomizer.randomColor(), coneSegments, isConeShape)
-    }
-
-    private var r3 = v.len()
-    private var v2 = Vector2(v).rotateRad(PI).setLength(c1.radius - r3)
-
-    // Third circle also positioned relative to the first
-    private var c3 = circlesPool.obtain().also {
-        it.init(width / 2 + v2.x, height / 2 + v2.y, 1 / r3, colorRandomizer.randomColor(), coneSegments, isConeShape)
-    }
+    private var v = Vector2(); var v2 = Vector2()
 
     // All circles in the gasket
-    private var allCircles = GdxArray<Circle>(false, 64).apply {
-        add(c1)
-        add(c2)
-        add(c3)
-    }
+    private var allCircles = GdxArray<Circle>(false, 64)
 
     // Queue for circles to process for next generation
-    private var queue = GdxArray<Triplet>(false, 64).apply {
-        // Initial triplet for generating next generation of circles
-        add(Triplet(c1, c2, c3))
-    }
+    private var queue = GdxArray<Triplet>(false, 64)
 
-    fun init() {
+    fun init(): Gasket {
         coneSegments = intArrayOf(4, 8, 20, 50).random()
         isConeShape = RandomXS128().nextInt(3) == 0
         colorRandomizer = ColorRandomizer()
@@ -97,7 +69,7 @@ class Gasket(private var width: Float, private var height: Float) {
         randomAngleRad = randomFloatRange(0f, 2 * PI)
 
         // Convert the angle to a unit vector
-        v = vec2(MathUtils.cos(randomAngleRad), MathUtils.sin(randomAngleRad))
+        v.set(MathUtils.cos(randomAngleRad), MathUtils.sin(randomAngleRad))
             .setLength(c1.radius - r2)
 
         // Second circle positioned randomly within the first
@@ -113,7 +85,7 @@ class Gasket(private var width: Float, private var height: Float) {
         }
 
         r3 = v.len()
-        v2 = Vector2(v).rotateRad(PI).setLength(c1.radius - r3)
+        v2.set(v).rotateRad(PI).setLength(c1.radius - r3)
 
         // Third circle also positioned relative to the first
         c3 = circlesPool.obtain().also {
@@ -139,6 +111,8 @@ class Gasket(private var width: Float, private var height: Float) {
             // Initial triplet for generating next generation of circles
             add(Triplet(c1, c2, c3))
         }
+
+        return this
     }
 
     fun draw(shape: ShapeRenderer) {

--- a/core/src/main/kotlin/io/github/thanosfisherman/gasket/Gasket.kt
+++ b/core/src/main/kotlin/io/github/thanosfisherman/gasket/Gasket.kt
@@ -117,16 +117,16 @@ class Gasket(private var width: Float, private var height: Float) : Pool.Poolabl
         }
     }
 
-    fun draw(shape: ShapeRenderer) {
-
-        val delta: Long = TimeUtils.millis() - lastTimeCounted
-        lastTimeCounted = TimeUtils.millis()
-
+    fun update(delta: Float) {
         sinceChange += delta
-        if (sinceChange >= 1) {
+
+        if (sinceChange >= 1f) {
             sinceChange = 0f
             nextGeneration()
         }
+    }
+
+    fun draw(shape: ShapeRenderer) {
         for (c in allCircles) {
             c.draw(shape)
         }

--- a/core/src/main/kotlin/io/github/thanosfisherman/gasket/Gasket.kt
+++ b/core/src/main/kotlin/io/github/thanosfisherman/gasket/Gasket.kt
@@ -15,8 +15,6 @@ import kotlin.math.abs
 
 // Tolerance for calculating tangency and overlap
 private const val epsilon = 1f
-private val width = Gdx.graphics.width.toFloat()
-private val height = Gdx.graphics.height.toFloat()
 
 class Gasket(viewport: Viewport) {
     private var coneSegments = intArrayOf(4, 8, 20, 50).random()
@@ -25,6 +23,9 @@ class Gasket(viewport: Viewport) {
     private var circlesPool: Pool<Circle> = pool(1200) { Circle(viewport) }
     private var lastTimeCounted = TimeUtils.millis()
     private var sinceChange = 0f
+
+    private var width = viewport.worldWidth
+    private var height = viewport.worldHeight
 
     // Initialize first circle centered on canvas
     private var c1 = circlesPool.obtain().also {

--- a/teavm/src/main/kotlin/io/github/thanosfisherman/gasket/teavm/TeaVMLauncher.kt
+++ b/teavm/src/main/kotlin/io/github/thanosfisherman/gasket/teavm/TeaVMLauncher.kt
@@ -21,8 +21,8 @@ object TeaVMLauncher {
         val config = TeaApplicationConfiguration("canvas").apply {
             antialiasing = true
             // change these to both 0 to use all available space, or both -1 for the canvas size.
-            width = 900
-            height = 900
+            width = 0
+            height = 0
         }
 
         TeaApplication(create(), config)


### PR DESCRIPTION
Hey there!

As mentioned I've implemented the fix and added some improvements:
1. You were using `Gdx.app.getWidth()` and `Gdx.app.getHeight()` instead of `viewport.worldWidth` and `viewport.worldHeight`. Since the desktop client is initialized with 900x900 it was not a problem there, however since the browser window is usually a different size, that created the problem you were facing.
2. I've also refactored viewports and batches, so that the screen manages both viewports, the `SpriteBatch` and the `ShapeRenderer`. This has the advantage that you create less draw calls (as every "begin/end" combo creates a new one. On top of that it creates less spaghetti code as the `Gasket`s or the Circles do not need to deal with managing the viewport anymore.
   1. I've also refactored the `Framerate` class as well for the viewport fix.
4. You were initializing the `Gasket`s twice, once in the properties, and once in your custom `init()` method. I've refactored it so it's only in the `init()` method.
5. And at last I've removed the `Gasket`s `init()` method, and replaced it with the `Pool.Poolables` `reset()` method. This means every time you `free()` a `Gasket` it gets recalculated automatically. 

Feel free to tell me if you want any of those commits removed from the PR in case you don't like those changes. :)
(Or decline it and do the `Gdx.app.getWidth()` fix manually) 

Have fun with it!
